### PR TITLE
Remove invalid feature document

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,6 @@ BabaSSL是一个现代的密码学和通信安全协议的基础库。BabaSSL诞
   * 支持GB/T 38636-2020 TLCP标准，即安全传输协议
   * 支持[QUIC](https://datatracker.ietf.org/doc/html/rfc9000) API
   * 支持Delegated Credentials功能，基于[draft-ietf-tls-subcerts-10](https://www.ietf.org/archive/id/draft-ietf-tls-subcerts-10.txt)
-  * 支持[RFC 8879](https://datatracker.ietf.org/doc/rfc8879/)，即证书压缩
   * ……
 
 ## 教程和API文档


### PR DESCRIPTION
Certificate compression is included in 8.3.0, not in 8.2.x